### PR TITLE
Apostrophe Search Fix

### DIFF
--- a/graphql/songs.js
+++ b/graphql/songs.js
@@ -8,9 +8,9 @@ export default {
 
       const query = search
         ? `SELECT * FROM songs
-      WHERE track_name LIKE '%${search}%'
-      OR track_artist LIKE '%${search}%'
-      OR track_album_name LIKE '%${search}%'
+      WHERE track_name LIKE "%${search}%"
+      OR track_artist LIKE "%${search}%"
+      OR track_album_name LIKE "%${search}%"
       ORDER BY track_name ASC
       LIMIT ${PER_PAGE} OFFSET ${offsetStart}`
         : `SELECT * FROM songs
@@ -28,9 +28,9 @@ export default {
       const totalResult = await db.exec(
         search
           ? `SELECT COUNT(*) FROM songs
-      WHERE track_name LIKE '%${search}%'
-      OR track_artist LIKE '%${search}%'
-      OR track_album_name LIKE '%${search}%'`
+      WHERE track_name LIKE "%${search}%"
+      OR track_artist LIKE "%${search}%"
+      OR track_album_name LIKE "%${search}%"`
           : 'SELECT COUNT(*) FROM songs'
       );
 

--- a/graphql/songs.js
+++ b/graphql/songs.js
@@ -6,11 +6,13 @@ export default {
       const offsetStart = PER_PAGE * (page - 1);
       const offsetEnd = offsetStart + PER_PAGE;
 
+      const escapedSearch = search ? search.replace('"', '') : '';
+
       const query = search
         ? `SELECT * FROM songs
-      WHERE track_name LIKE "%${search}%"
-      OR track_artist LIKE "%${search}%"
-      OR track_album_name LIKE "%${search}%"
+      WHERE track_name LIKE "%${escapedSearch}%"
+      OR track_artist LIKE "%${escapedSearch}%"
+      OR track_album_name LIKE "%${escapedSearch}%"
       ORDER BY track_name ASC
       LIMIT ${PER_PAGE} OFFSET ${offsetStart}`
         : `SELECT * FROM songs
@@ -28,9 +30,9 @@ export default {
       const totalResult = await db.exec(
         search
           ? `SELECT COUNT(*) FROM songs
-      WHERE track_name LIKE "%${search}%"
-      OR track_artist LIKE "%${search}%"
-      OR track_album_name LIKE "%${search}%"`
+      WHERE track_name LIKE "%${escapedSearch}%"
+      OR track_artist LIKE "%${escapedSearch}%"
+      OR track_album_name LIKE "%${escapedSearch}%"`
           : 'SELECT COUNT(*) FROM songs'
       );
 


### PR DESCRIPTION
⚠️ NOTE! ⚠️ 

If a user enters a double-quote into the search string, it will be removed before running the query. This was to prevent that same error behavior from happening with double-quotes as well as single-quotes. In a future pull request (pretending this is real), we should properly handle searching for double-quotes.