### PR TITLE
Genre Nav Bar

### DIFF
--- a/components/genre.js
+++ b/components/genre.js
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import { request, gql } from 'graphql-request';
 import useSWR from 'swr';
 
@@ -39,7 +40,7 @@ const fetcher = genre =>
     genre
   });
 
-export default function Genre({ genre }) {
+const Genre = forwardRef(({ genre }, ref) => {
   const { data, error } = useSWR([genre], fetcher);
 
   if (!data && !error)
@@ -64,7 +65,7 @@ export default function Genre({ genre }) {
 
   return (
     <div className="container">
-      <h2 className="text-capitalize py-5">{genre}</h2>
+      <h2 className="text-capitalize py-5" ref={ref}>{genre}</h2>
       {data.SongsByGenre.length ? (
         <div className="row row-cols-1 row-cols-sm-3 row-cols-lg-5 g-3">
           {data.SongsByGenre.map(song => (
@@ -76,4 +77,6 @@ export default function Genre({ genre }) {
       )}
     </div>
   );
-}
+});
+
+export default Genre;

--- a/components/genres.js
+++ b/components/genres.js
@@ -6,7 +6,7 @@ const GENRES = ['rap', 'pop', 'edm', 'r&b', 'rock', 'latin'];
 const GenreNavButton = ({ isSelected, genre, onClick }) => 
   <button
     type="button"
-    className={`text-capitalize btn btn-${isSelected ? 'primary' : 'light'} m-2`}
+    className={`text-capitalize m-2 btn btn-${isSelected ? 'primary' : 'light'}`}
     style={{ width: `${Math.floor(85 / GENRES.length)}%` }}
     onClick={onClick}
   >
@@ -25,7 +25,7 @@ export default function Genres() {
 
   return (
     <>
-      <div className="sticky-top p-2">
+      <div className="sticky-top p-2 bg-light">
         {GENRES.map(genre => (
           <GenreNavButton key={genre} genre={genre} isSelected={genre === selectedGenre} onClick={() => { scrollToGenre(genre); setSelectedGenre(genre); }} />
         ))}

--- a/components/genres.js
+++ b/components/genres.js
@@ -1,13 +1,37 @@
+import { useState, createRef, forwardRef } from 'react';
 import Genre from './genre';
 
 const GENRES = ['rap', 'pop', 'edm', 'r&b', 'rock', 'latin'];
 
+const GenreNavButton = ({ isSelected, genre, onClick }) => 
+  <button
+    type="button"
+    className={`text-capitalize btn btn-${isSelected ? 'primary' : 'light'} m-2`}
+    style={{ width: `${Math.floor(85 / GENRES.length)}%` }}
+    onClick={onClick}
+  >
+    {genre}
+  </button>;
+
 export default function Genres() {
+  const [selectedGenre, setSelectedGenre] = useState('');
+  const genreRefs = {};
+
+  const createGenreSection = (genre) => {
+    genreRefs[genre] = createRef();
+    return <Genre ref={genreRefs[genre]} key={genre} genre={genre} />;
+  };
+  const scrollToGenre = (genre) => genreRefs[genre].current.scrollIntoView();
+
   return (
     <>
-      {GENRES.map(genre => (
-        <Genre key={genre} genre={genre} />
-      ))}
+      <div className="sticky-top p-2">
+        {GENRES.map(genre => (
+          <GenreNavButton key={genre} genre={genre} isSelected={genre === selectedGenre} onClick={() => { scrollToGenre(genre); setSelectedGenre(genre); }} />
+        ))}
+      </div>
+
+      {GENRES.map(genre => createGenreSection(genre))}
     </>
   );
 }

--- a/components/genres.js
+++ b/components/genres.js
@@ -1,4 +1,5 @@
 import { useState, createRef, forwardRef } from 'react';
+import VisibilitySensor from 'react-visibility-sensor';
 import Genre from './genre';
 
 const GENRES = ['rap', 'pop', 'edm', 'r&b', 'rock', 'latin'];
@@ -14,18 +15,29 @@ const GenreNavButton = ({ isSelected, genre, onClick }) =>
   </button>;
 
 export default function Genres() {
-  const [selectedGenre, setSelectedGenre] = useState('');
+  const [selectedGenre, setSelectedGenre] = useState(GENRES[0]);
   const genreRefs = {};
 
   const createGenreSection = (genre) => {
     genreRefs[genre] = createRef();
-    return <Genre ref={genreRefs[genre]} key={genre} genre={genre} />;
+    return (
+      <VisibilitySensor
+        key={genre}
+        onChange={(isVisible) => {
+          if (isVisible) setSelectedGenre(genre);
+          console.log(`${genre} isVisible: ${isVisible}`);
+        }}
+      >
+        <Genre ref={genreRefs[genre]} genre={genre} />
+      </VisibilitySensor>
+    );
   };
+
   const scrollToGenre = (genre) => genreRefs[genre].current.scrollIntoView();
 
   return (
     <>
-      <div className="sticky-top p-2 bg-light">
+      <div className="sticky-top pb-2 px-2 bg-light">
         {GENRES.map(genre => (
           <GenreNavButton key={genre} genre={genre} isSelected={genre === selectedGenre} onClick={() => { scrollToGenre(genre); setSelectedGenre(genre); }} />
         ))}

--- a/components/genres.js
+++ b/components/genres.js
@@ -1,4 +1,4 @@
-import { useState, createRef, forwardRef } from 'react';
+import { useState, createRef, useEffect } from 'react';
 import VisibilitySensor from 'react-visibility-sensor';
 import Genre from './genre';
 
@@ -16,7 +16,17 @@ const GenreNavButton = ({ isSelected, genre, onClick }) =>
 
 export default function Genres() {
   const [selectedGenre, setSelectedGenre] = useState(GENRES[0]);
+  const [useVisibilitySensor, setUseVisibilitySensor] = useState(false);
   const genreRefs = {};
+
+  const pauseVisibilitySensor = (timeout) => {
+    setUseVisibilitySensor(false);
+    setTimeout(() => setUseVisibilitySensor(true), timeout);
+  };
+
+  useEffect(() => {
+    pauseVisibilitySensor(20);
+  }, [])
 
   const createGenreSection = (genre) => {
     genreRefs[genre] = createRef();
@@ -24,7 +34,7 @@ export default function Genres() {
       <VisibilitySensor
         key={genre}
         onChange={(isVisible) => {
-          if (isVisible) setSelectedGenre(genre);
+          if (useVisibilitySensor && isVisible) setSelectedGenre(genre);
           console.log(`${genre} isVisible: ${isVisible}`);
         }}
       >
@@ -39,7 +49,7 @@ export default function Genres() {
     <>
       <div className="sticky-top pb-2 px-2 bg-light">
         {GENRES.map(genre => (
-          <GenreNavButton key={genre} genre={genre} isSelected={genre === selectedGenre} onClick={() => { scrollToGenre(genre); setSelectedGenre(genre); }} />
+          <GenreNavButton key={genre} genre={genre} isSelected={genre === selectedGenre} onClick={() => { pauseVisibilitySensor(600); scrollToGenre(genre); setSelectedGenre(genre); }} />
         ))}
       </div>
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next": "^12.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-visibility-sensor": "^5.1.1",
     "sql.js": "^1.6.2",
     "swr": "^1.0.1"
   },


### PR DESCRIPTION
This pull request adds a genre navigation bar to the top of the genre page that allows users to quickly jump between different genres.  The buttons with each navigation label light up as the user scrolls over them.

This implementation isn't the best and if I had more time, I would have liked to find a different method for accomplishing this; the method I used here has some naive approaches that I settled for due to time restraints.  I'm looking forward to discussing more in depth over the phone.